### PR TITLE
Fix path to mysql-import-anonymous-data

### DIFF
--- a/configure-repositories.py
+++ b/configure-repositories.py
@@ -105,7 +105,7 @@ def setup_local_mysql_database(repo):
         package_json["scripts"].update(
             {
                 "mysql": "docker compose exec mysql serlo-mysql",
-                "mysql:import-anonymous-data": f"{ts_node_cmd} mysql/scripts/mysql-import-anonymous-data",
+                "mysql:import-anonymous-data": f"{ts_node_cmd} scripts/mysql/mysql-import-anonymous-data",
                 "mysql:rollback": f'docker compose exec mysql sh -c "pv /docker-entrypoint-initdb.d/001-init.sql | serlo-mysql"',
                 "start:docker": "docker compose up --detach",
                 "stop:docker": "docker compose down",


### PR DESCRIPTION
Since we moved the scripts to the `scripts/mysql` path, the template used to call the script needs to be updated as well.